### PR TITLE
349 generic elastic authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,17 @@ jdk:
  - oraclejdk8
 sudo: false
 
+services:
+  - elasticsearch
+
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
 env:
-  - MAILGUN_API_KEY=notarealkey DATABASE_URL=jdbc:postgresql://localhost/travis_ci_test
-addons:
-  postgresql: "9.4"
+  - MAILGUN_API_KEY=notarealkey
+
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M coverage test
   # Tricks to avoid unnecessary cache updates
@@ -23,4 +25,5 @@ script:
 after_success: "sbt coveralls"
 before_script:
 before_script:
-  - psql -c 'create database travis_ci_test;' -U postgres
+  - sleep 10
+  - curl -XPUT 'http://127.0.0.1:9200/scoap3/'

--- a/app/controllers/Search.scala
+++ b/app/controllers/Search.scala
@@ -26,6 +26,8 @@ import models.{HubUtils, Item, Subscriber, Topic}
 object Search extends Controller {
 
   val indexSvc = Play.configuration.getString("hub.index.url").get
+  val indexUser = Play.configuration.getString("hub.index.username").getOrElse("")
+  val indexPwd = Play.configuration.getString("hub.index.password").getOrElse("")
   val adminEmail = Play.configuration.getString("hub.admin.email").get
   val iso8601 = ISODateTimeFormat.dateTimeNoMillis.withZone(DateTimeZone.UTC)
 
@@ -133,12 +135,9 @@ object Search extends Controller {
     val encQuery = UriEncoding.encodePathSegment(query, "UTF-8")
     val offset = (page) * perpage
     val elastic_url = indexSvc +  target + "/_search?q=" + encQuery + "&from=" + offset + "&size=" + perpage
-    if (indexSvc.contains("bonsai.io")) {
+    if (indexUser != "" && indexPwd != "") {
       Logger.debug("use basic auth for WS elasticsearch call")
-      WS.url(elastic_url)
-        .withAuth(extractCredentials("username", indexSvc),
-                  extractCredentials("password", indexSvc),
-                  WSAuthScheme.BASIC)
+      WS.url(elastic_url).withAuth(indexUser, indexPwd, WSAuthScheme.BASIC)
     } else {
       Logger.debug("no auth for WS elasticsearch call")
       WS.url(elastic_url)

--- a/app/views/search/searchform.scala.html
+++ b/app/views/search/searchform.scala.html
@@ -5,9 +5,9 @@
     <div class="col-sm-8">
       <input name="q" class="form-control" id="inputQuery" placeholder="why don't you just type what you want to find..." value="@q">
     </div>
-    <button type="submit" class="btn btn-primary">Search!</button>
+    <button type="submit" id="search_submit" class="btn btn-primary">Search!</button>
   </div>
-  
+
   <div class="form-group">
     <div class="col-sm-2 control-label"><label for="target">Target</label></div>
     <div class="col-sm-10">

--- a/app/workers/Indexer.scala
+++ b/app/workers/Indexer.scala
@@ -36,18 +36,19 @@ object Indexer {
   import play.api.libs.json.Json._
 
   val indexSvc = Play.configuration.getString("hub.index.url").get
+  val indexUser = Play.configuration.getString("hub.index.username").getOrElse("")
+  val indexPwd = Play.configuration.getString("hub.index.password").getOrElse("")
 
   def reindex(dtype: String) = {
     // delete current index type
-    if (indexSvc.contains("bonsai.io")) {
+    if (indexUser != "" && indexPwd != "") {
       Logger.debug("Use basic auth for WS elasticsearch call")
-      WS.url(indexSvc + dtype)
-        .withAuth(extractCredentials("username", indexSvc),
-                  extractCredentials("password", indexSvc),
-                  WSAuthScheme.BASIC).delete()
+      WS.url(indexSvc + dtype).withAuth(indexUser, indexPwd, WSAuthScheme.BASIC).delete()
+      WS.url(indexSvc + dtype).withAuth(indexUser, indexPwd, WSAuthScheme.BASIC).withMethod("PUT").stream
     } else {
       Logger.debug("No auth for WS elasticsearch call")
       WS.url(indexSvc + dtype).delete()
+      WS.url(indexSvc + dtype).withMethod("PUT").stream
     }
 
     if ("topic".equals(dtype)) {
@@ -65,6 +66,9 @@ object Indexer {
                    "name" -> toJson(topic.name))
     val elastic_url = indexSvc.concat("topic/").concat(topic.id.toString)
     indexDocument(elastic_url, stringify(toJson(data)))
+    Logger.debug("Topic index: " + data)
+    // sleep required to prevent elasticsearch service from dropping records
+    Thread sleep 100
   }
 
   def deindex(topic: Topic) = {
@@ -83,7 +87,8 @@ object Indexer {
     dataMap += "topicTag" -> toJson(item.topics.map(_.tag))
     indexDocument(elastic_url, stringify(toJson(dataMap)))
     Logger.debug("Item index: " + dataMap)
-    Logger.debug(indexSvc + "item/" + item.id)
+    // sleep required to prevent elasticsearch service from dropping records
+    Thread sleep 100
   }
 
   def deindex(item: Item) = {
@@ -91,12 +96,9 @@ object Indexer {
   }
 
   private def indexDocument(url: String, jdata: String) = {
-    if (indexSvc.contains("bonsai.io")) {
+    if (indexUser != "" && indexPwd != "") {
       Logger.debug("Use basic auth for WS elasticsearch call")
-      WS.url(url)
-        .withAuth(extractCredentials("username", indexSvc),
-                  extractCredentials("password", indexSvc),
-                  WSAuthScheme.BASIC).put(jdata)
+      WS.url(url).withAuth(indexUser, indexPwd, WSAuthScheme.BASIC).put(jdata)
     } else {
       Logger.debug("No auth for WS elasticsearch call")
       WS.url(url).put(jdata)
@@ -104,12 +106,9 @@ object Indexer {
   }
 
   private def deleteDocument(url: String) = {
-    if (indexSvc.contains("bonsai.io")) {
+    if (indexUser != "" && indexPwd != "") {
       Logger.debug("Use basic auth for WS elasticsearch call")
-      WS.url(url)
-        .withAuth(extractCredentials("username", indexSvc),
-                  extractCredentials("password", indexSvc),
-                  WSAuthScheme.BASIC).delete
+      WS.url(url).withAuth(indexUser, indexPwd, WSAuthScheme.BASIC).delete
     } else {
       Logger.debug("No auth for WS elasticsearch call")
       WS.url(url).delete
@@ -120,19 +119,4 @@ object Indexer {
     // NB: need logic here to test whether scheme is metadata or not
     scheme.tag -> toJson(item.metadataValue(scheme.tag))
   }
-
-  /*
-  def index(subscriber: Subscriber) = {
-    // minimal indexing: dbId, schemeId, topicId, and title
-    val data = Map("dbId" -> toJson(subscriber.id),
-                   "category" -> toJson(subscriber.category),
-                   "keywords" -> toJson(subscriber.keywords),
-                   "name" -> toJson(subscriber.name))
-    val jdata = stringify(toJson(data))
-    // debug
-    Logger.info("Subscriber index: " + jdata)
-    val req = WS.url(indexSvc + "subscriber/" + subscriber.id)
-    req.put(jdata)
-  }
-  */
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -56,7 +56,7 @@ hub.admin.email="topichub-admin@mit.edu"
 hub.admin.email=${?ADMIN_EMAIL}
 
 # URL of indexing service
-hub.index.url="http://localhost:9200/scoap3/"
+hub.index.url="http://127.0.0.1:9200/scoap3/"
 hub.index.url=${?ELASTIC_URL}
 hub.index.username=${?ELASTIC_USER}
 hub.index.password=${?ELASTIC_PASSWORD}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,7 +57,9 @@ hub.admin.email=${?ADMIN_EMAIL}
 
 # URL of indexing service
 hub.index.url="http://localhost:9200/scoap3/"
-hub.index.url=${?BONSAI_URL}
+hub.index.url=${?ELASTIC_URL}
+hub.index.username=${?ELASTIC_USER}
+hub.index.password=${?ELASTIC_PASSWORD}
 
 # URL of email service, and API key to use it
 hub.email.url="https://api.mailgun.net/v2/topichub.mailgun.org/messages"

--- a/test/integration/SearchPagesSpec.scala
+++ b/test/integration/SearchPagesSpec.scala
@@ -1,0 +1,120 @@
+import org.specs2.mutable._
+import org.specs2.runner._
+import java.util.Date
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.fest.assertions.Assertions.assertThat
+import play.api.Application
+import play.api.Play
+import play.api.Play.current
+import models.{ Channel, Collection, ContentType, Harvest, Item, Publisher, ResourceMap, Scheme,
+                Subscriber, Topic, User }
+import workers.Indexer
+
+/**
+ * An integration test will fire up a whole play application in a real (or headless) browser
+ */
+class SearchPagesSpec extends Specification {
+
+  def create_user(role: String) = User.make("bob", "bob@example.com", role,
+                                            "https://oidc.mit.edu/current_user")
+  def item_factory(count: Int) {
+    val ct = ContentType.make("tag", "label", "desc", Some("logo"))
+    val rm = ResourceMap.make("rm_tag", "rm_desc", Some("http://www.example.com"))
+    val user = User.make("pubuser", "pubuser@example.com", "", "pub_identity")
+    val pub = Publisher.make(user.id, "pubtag", "pubname", "pubdesc", "pubcat", "pubstatus",
+                             Some(""), Some(""))
+    val col = Collection.make(pub.id, ct.id, rm.id, "coll1_tag", "coll1 desc", "open")
+  }
+
+  "Search pages" should {
+    "index" in new WithBrowser(
+      app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.pageSource must contain("Search for stuff!")
+    }
+
+    "can search for items by scheme" in new WithBrowser(
+      app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      item_factory(1)
+      val i = Item.make(1, 1, "location", "abc:123")
+      val s1 = Scheme.make("scheme_1_tag", "gentype", "cat", "scheme_1 description",
+                           Some("link"), Some("logo"))
+      val s2 = Scheme.make("scheme_2_tag", "gentype", "cat", "scheme_2 description",
+                           Some("link"), Some("logo"))
+      val s3 = Scheme.make("scheme_with_no_items", "gentype", "cat", "scheme_2 description",
+                          Some("link"), Some("logo"))
+      i.addMetadata("title", "I like popcorn")
+      val t1 = Topic.make(s1.id, "tag1", "name1")
+      val t2 = Topic.make(s2.id, "tag2", "name2")
+      i.addTopic(t1)
+      i.addTopic(t2)
+      Indexer.deindex_all("topic")
+      Thread sleep 500
+      Indexer.reindex("item")
+      Thread sleep 500
+
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.pageSource must contain("Search for stuff!")
+      browser.$("#target_item").click
+      browser.$("#inputQuery").text("scheme_1_tag")
+      browser.$("#search_submit").click
+      browser.pageSource must contain("Viewing all 1 records.")
+      browser.pageSource must contain("I like popcorn")
+
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.$("#target_item").click
+      browser.$("#inputQuery").text("scheme_2_tag")
+      browser.$("#search_submit").click
+      browser.pageSource must contain("Viewing all 1 records.")
+      browser.pageSource must contain("I like popcorn")
+
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.$("#target_item").click
+      browser.$("#inputQuery").text("scheme_with_no_items")
+      browser.$("#search_submit").click
+      browser.pageSource must contain("Viewing all 0 records.")
+      browser.pageSource must not contain("I like popcorn")
+
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.$("#target_item").click
+      browser.$("#inputQuery").text("non_existing_scheme")
+      browser.$("#search_submit").click
+      browser.pageSource must contain("Viewing all 0 records.")
+      browser.pageSource must not contain("I like popcorn")
+      Indexer.deindex_all("item")
+      Thread sleep 500
+    }
+
+    "can search for topics" in new WithBrowser(
+      app = FakeApplication(additionalConfiguration = inMemoryDatabase())) {
+      val s1 = Scheme.make("scheme_1_tag", "gentype", "cat", "scheme_1 description",
+                           Some("link"), Some("logo"))
+      val s2 = Scheme.make("scheme_2_tag", "gentype", "cat", "scheme_2 description",
+                           Some("link"), Some("logo"))
+      val s3 = Scheme.make("scheme_with_no_items", "gentype", "cat", "scheme_2 description",
+                          Some("link"), Some("logo"))
+      val t1 = Topic.make(s1.id, "Some Institution, Anytown, ST 02140", "No Label")
+      val t2 = Topic.make(s2.id, "Dept. of Stuff, Some Institution, Anytown, ST 02140", "No Label")
+      val t3 = Topic.make(s2.id, "Another Place, Anytown, ST 02140", "No Label")
+
+      Indexer.deindex_all("item")
+      Thread sleep 500
+      Indexer.reindex("topic")
+      Thread sleep 500
+
+      browser.goTo("http://localhost:" + port + "/search")
+      browser.pageSource must contain("Search for stuff!")
+      browser.$("#inputQuery").text("Some Institution")
+      browser.$("#search_submit").click
+      browser.pageSource must contain("Viewing all 2 records.")
+      browser.pageSource must contain(t1.tag)
+      browser.pageSource must contain(t2.tag)
+      browser.pageSource must not contain(t3.tag)
+
+      Indexer.deindex_all("topic")
+      Thread sleep 500
+    }
+  }
+}


### PR DESCRIPTION
- Allows for authenticated, non-bonsai, elasticsearch. I've got some thread sleeps in there to prevent issues where we were sending data too fast for an upstream provider (at least on a free tier). A full reindex is now slower of course, but still completes in a reasonable amount of time. The delays should be unnoticeable to end users, but I still hate them. Ideally we'd read responses back and act accordingly (either sleeping or resending based on what the provider can seem to handle), but that level of refactor was way outside the scope of what I intended to do with this work.
closes #349 

- This also provides some initial integration tests with elasticsearch. Running tests locally now require an elasticsearch instance running. Travis spins one up for us. Much more can/should be tested, but this serves as a decent starting point.  The tests have sleeps as well (ugh), to allow for the reindex job to complete before querying. This is awful and prone to race conditions in which the sleep completes and the indexing has not been completed and thus the test fails. When (not if) it starts to get flakey enough to be annoying it can be rethought though. This is part of #357 (which will remain open as testing is still weak).
