### PR TITLE
METS author limits, date created, and TopicHub as agent

### DIFF
--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -214,7 +214,7 @@ case class Item(id: Int,            // DB key
                   </epdcx:statement>
                 }
 
-                <epdcx:statement epdcx:propertyURI="http://purl.org/dc/terms/Agent">
+                <epdcx:statement epdcx:propertyURI="http://purl.org/dc/elements/1.1/source">
                   <epdcx:valueString>TopicHub SCOAP3</epdcx:valueString>
                 </epdcx:statement>
 

--- a/app/models/Item.scala
+++ b/app/models/Item.scala
@@ -137,7 +137,7 @@ case class Item(id: Int,            // DB key
   }
 
   private def metsHdr = {
-    <metsHdr CREATEDATE={metadataValue("title")}>
+    <metsHdr CREATEDATE={ HubUtils.fmtDate(created) }>
       <agent ROLE="CREATOR" TYPE="ORGANIZATION">
         <name>TopicHub</name>
       </agent>
@@ -158,7 +158,7 @@ case class Item(id: Int,            // DB key
                   </epdcx:statement>
                 }
 
-                { if( hasMetadata("author") )
+                { if( hasMetadata("author") && include_authors)
                   { for ( author <- metadataValues("author") ) yield
                     <epdcx:statement epdcx:propertyURI="http://purl.org/dc/elements/1.1/creator">
                       <epdcx:valueString>{ author }</epdcx:valueString>
@@ -166,7 +166,7 @@ case class Item(id: Int,            // DB key
                   }
                 }
 
-                { if( hasMetadata("additional_author") )
+                { if( hasMetadata("additional_author") && include_authors)
                   { for ( author <- metadataValues("additional_author") ) yield
                     <epdcx:statement epdcx:propertyURI="http://purl.org/dc/elements/1.1/creator">
                       <epdcx:valueString>{ author }</epdcx:valueString>
@@ -214,6 +214,10 @@ case class Item(id: Int,            // DB key
                   </epdcx:statement>
                 }
 
+                <epdcx:statement epdcx:propertyURI="http://purl.org/dc/terms/Agent">
+                  <epdcx:valueString>TopicHub SCOAP3</epdcx:valueString>
+                </epdcx:statement>
+
               </epdcx:description>
             </epdcx:descriptionSet>
           </xmlData>
@@ -251,6 +255,16 @@ case class Item(id: Int,            // DB key
 
       </div>
     </structMap>
+  }
+
+  private def include_authors: Boolean = {
+    val restrict_at = current.configuration.getInt("mets.restrict_maximum_authors").getOrElse(0)
+    val author_size = metadataValues("author").size + metadataValues("additional_author").size
+    if (restrict_at == 0 || author_size < restrict_at) {
+      true
+    } else {
+      false
+    }
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -73,6 +73,10 @@ include "authentication"
 auth.harvest.key = ""
 auth.harvest.key = ${?HARVEST_KEY}
 
+# restrict excessive authors in METS?
+# to restrict add an Integer to METS_RESTRICT_MAXIMUM_AUTHORS
+mets.restrict_maximum_authors = ${?METS_RESTRICT_MAXIMUM_AUTHORS}
+
 # Branding changes should be made using Environment Variables
 # Developers should access values via the HubUtils model rather than directly.
 brand.name=${?SITE_NAME}

--- a/test/unit/ItemSpec.scala
+++ b/test/unit/ItemSpec.scala
@@ -490,11 +490,11 @@ class ItemSpec extends Specification {
         (mets \\ "dmdSec").size must equalTo(1)
         (mets \\ "fileSec").size must equalTo(1)
         (mets \\ "structMap").size must equalTo(1)
-        (mets \\ "valueString").size must equalTo(3)
+        (mets \\ "valueString").size must equalTo(4)
 
         item.addMetadata("abstract", "More stuff!!!")
         val mets_abstract = item.toMets
-        (mets_abstract \\ "valueString").size must equalTo(4)
+        (mets_abstract \\ "valueString").size must equalTo(5)
 
         item.addMetadata("doi", "asdf//popcorn.123.456")
         item.addMetadata("additional_author", "Anonymoys Coward")
@@ -505,7 +505,7 @@ class ItemSpec extends Specification {
         item.addMetadata("accessUri", "http://example.com/a.pdf?pdfa")
         item.addMetadata("accessUri", "http://example.com/a.xml")
         val mets_moar = item.toMets
-        (mets_moar \\ "valueString").size must equalTo(9)
+        (mets_moar \\ "valueString").size must equalTo(10)
         (mets_moar \\ "FLocat").size must equalTo(3)
         (mets_moar \\ "fptr").size must equalTo(3)
       }


### PR DESCRIPTION
This allows setting METS_RESTRICT_MAXIMUM_AUTHORS to an integer. If
there are more authors than that number, none are supplied in the METS
to prevent triggering a bug in our local DSpace installation.

Fixes a bug where we included a title instead of the date.

Adds dc.agent as a mechanism for detecting the package came from
TopicHub. If a better field is identified, this could be changed and we
can work with Carl to update the crosswalk that relies on this value.

closes #371
closes #370
closes #375